### PR TITLE
remove old-merge-schemas from oapi-gen config

### DIFF
--- a/oapi-gen.yml
+++ b/oapi-gen.yml
@@ -4,7 +4,6 @@ generate:
   models: true
   client: true
 compatibility:
-  old-merge-schemas: true
   always-prefix-enum-values: true
 output: sdk.gen.go
 output-options:

--- a/sdk.gen.go
+++ b/sdk.gen.go
@@ -22,6 +22,20 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
+// Defines values for AdvancedRulePhase.
+const (
+	AdvancedRulePhaseAccess       AdvancedRulePhase = "access"
+	AdvancedRulePhaseBodyFilter   AdvancedRulePhase = "body_filter"
+	AdvancedRulePhaseHeaderFilter AdvancedRulePhase = "header_filter"
+)
+
+// Defines values for AdvancedRuleResponsePhase.
+const (
+	AdvancedRuleResponsePhaseAccess       AdvancedRuleResponsePhase = "access"
+	AdvancedRuleResponsePhaseBodyFilter   AdvancedRuleResponsePhase = "body_filter"
+	AdvancedRuleResponsePhaseHeaderFilter AdvancedRuleResponsePhase = "header_filter"
+)
+
 // Defines values for ApiPathHttpScheme.
 const (
 	ApiPathHttpSchemeHTTP  ApiPathHttpScheme = "HTTP"
@@ -265,6 +279,13 @@ const (
 	TrafficTypeTimeout           TrafficType = "timeout"
 )
 
+// Defines values for UpdateAdvancedRulePhase.
+const (
+	UpdateAdvancedRulePhaseAccess       UpdateAdvancedRulePhase = "access"
+	UpdateAdvancedRulePhaseBodyFilter   UpdateAdvancedRulePhase = "body_filter"
+	UpdateAdvancedRulePhaseHeaderFilter UpdateAdvancedRulePhase = "header_filter"
+)
+
 // Defines values for UrlConditionMatchType.
 const (
 	UrlConditionMatchTypeContains UrlConditionMatchType = "Contains"
@@ -296,6 +317,22 @@ const (
 	GetDomainsV1DomainsGetParamsOrderingMinusStatus    GetDomainsV1DomainsGetParamsOrdering = "-status"
 	GetDomainsV1DomainsGetParamsOrderingName           GetDomainsV1DomainsGetParamsOrdering = "name"
 	GetDomainsV1DomainsGetParamsOrderingStatus         GetDomainsV1DomainsGetParamsOrdering = "status"
+)
+
+// Defines values for GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering.
+const (
+	GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrderingAction           GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering = "action"
+	GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrderingDescription      GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering = "description"
+	GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrderingEnabled          GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering = "enabled"
+	GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrderingId               GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering = "id"
+	GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrderingMinusAction      GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering = "-action"
+	GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrderingMinusDescription GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering = "-description"
+	GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrderingMinusEnabled     GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering = "-enabled"
+	GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrderingMinusId          GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering = "-id"
+	GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrderingMinusName        GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering = "-name"
+	GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrderingMinusPhase       GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering = "-phase"
+	GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrderingName             GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering = "name"
+	GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrderingPhase            GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering = "phase"
 )
 
 // Defines values for GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsPhase.
@@ -343,6 +380,20 @@ const (
 	GetApiPathsV1DomainsDomainIdApiPathsGetParamsOrderingStatus             GetApiPathsV1DomainsDomainIdApiPathsGetParamsOrdering = "status"
 )
 
+// Defines values for GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering.
+const (
+	GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrderingAction           GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering = "action"
+	GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrderingDescription      GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering = "description"
+	GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrderingEnabled          GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering = "enabled"
+	GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrderingId               GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering = "id"
+	GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrderingMinusAction      GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering = "-action"
+	GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrderingMinusDescription GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering = "-description"
+	GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrderingMinusEnabled     GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering = "-enabled"
+	GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrderingMinusId          GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering = "-id"
+	GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrderingMinusName        GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering = "-name"
+	GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrderingName             GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering = "name"
+)
+
 // Defines values for GetDdosAttacksV1DomainsDomainIdDdosAttacksGetParamsOrdering.
 const (
 	GetDdosAttacksV1DomainsDomainIdDdosAttacksGetParamsOrderingEndTime        GetDdosAttacksV1DomainsDomainIdDdosAttacksGetParamsOrdering = "end_time"
@@ -358,12 +409,50 @@ const (
 	GetDdosInfoV1DomainsDomainIdDdosInfoGetParamsGroupByUserAgent GetDdosInfoV1DomainsDomainIdDdosInfoGetParamsGroupBy = "User-Agent"
 )
 
+// Defines values for GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering.
+const (
+	GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrderingAction           GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering = "action"
+	GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrderingDescription      GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering = "description"
+	GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrderingEnabled          GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering = "enabled"
+	GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrderingId               GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering = "id"
+	GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrderingMinusAction      GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering = "-action"
+	GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrderingMinusDescription GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering = "-description"
+	GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrderingMinusEnabled     GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering = "-enabled"
+	GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrderingMinusId          GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering = "-id"
+	GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrderingMinusName        GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering = "-name"
+	GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrderingName             GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering = "name"
+)
+
 // Defines values for GetRequestsV1DomainsDomainIdRequestsGetParamsActions.
 const (
 	GetRequestsV1DomainsDomainIdRequestsGetParamsActionsAllow     GetRequestsV1DomainsDomainIdRequestsGetParamsActions = "allow"
 	GetRequestsV1DomainsDomainIdRequestsGetParamsActionsBlock     GetRequestsV1DomainsDomainIdRequestsGetParamsActions = "block"
 	GetRequestsV1DomainsDomainIdRequestsGetParamsActionsCaptcha   GetRequestsV1DomainsDomainIdRequestsGetParamsActions = "captcha"
 	GetRequestsV1DomainsDomainIdRequestsGetParamsActionsHandshake GetRequestsV1DomainsDomainIdRequestsGetParamsActions = "handshake"
+)
+
+// Defines values for GetEventStatisticsV1DomainsDomainIdStatsGetParamsAction.
+const (
+	GetEventStatisticsV1DomainsDomainIdStatsGetParamsActionBlock     GetEventStatisticsV1DomainsDomainIdStatsGetParamsAction = "block"
+	GetEventStatisticsV1DomainsDomainIdStatsGetParamsActionCaptcha   GetEventStatisticsV1DomainsDomainIdStatsGetParamsAction = "captcha"
+	GetEventStatisticsV1DomainsDomainIdStatsGetParamsActionHandshake GetEventStatisticsV1DomainsDomainIdStatsGetParamsAction = "handshake"
+	GetEventStatisticsV1DomainsDomainIdStatsGetParamsActionMonitor   GetEventStatisticsV1DomainsDomainIdStatsGetParamsAction = "monitor"
+)
+
+// Defines values for GetEventStatisticsV1DomainsDomainIdStatsGetParamsResult.
+const (
+	GetEventStatisticsV1DomainsDomainIdStatsGetParamsResultAllowed   GetEventStatisticsV1DomainsDomainIdStatsGetParamsResult = "allowed"
+	GetEventStatisticsV1DomainsDomainIdStatsGetParamsResultBlocked   GetEventStatisticsV1DomainsDomainIdStatsGetParamsResult = "blocked"
+	GetEventStatisticsV1DomainsDomainIdStatsGetParamsResultMonitored GetEventStatisticsV1DomainsDomainIdStatsGetParamsResult = "monitored"
+	GetEventStatisticsV1DomainsDomainIdStatsGetParamsResultPassed    GetEventStatisticsV1DomainsDomainIdStatsGetParamsResult = "passed"
+)
+
+// Defines values for GetOrganizationsV1OrganizationsGetParamsOrdering.
+const (
+	GetOrganizationsV1OrganizationsGetParamsOrderingId        GetOrganizationsV1OrganizationsGetParamsOrdering = "id"
+	GetOrganizationsV1OrganizationsGetParamsOrderingMinusId   GetOrganizationsV1OrganizationsGetParamsOrdering = "-id"
+	GetOrganizationsV1OrganizationsGetParamsOrderingMinusName GetOrganizationsV1OrganizationsGetParamsOrdering = "-name"
+	GetOrganizationsV1OrganizationsGetParamsOrderingName      GetOrganizationsV1OrganizationsGetParamsOrdering = "name"
 )
 
 // Defines values for GetInsightTypesV1SecurityInsightsTypesGetParamsOrdering.
@@ -388,12 +477,20 @@ const (
 	GetStatisticsSeriesV1StatisticsSeriesGetParamsMetricsTotalRequests GetStatisticsSeriesV1StatisticsSeriesGetParamsMetrics = "total_requests"
 )
 
+// Defines values for GetTagsV1TagsGetParamsOrdering.
+const (
+	GetTagsV1TagsGetParamsOrderingMinusName         GetTagsV1TagsGetParamsOrdering = "-name"
+	GetTagsV1TagsGetParamsOrderingMinusReadableName GetTagsV1TagsGetParamsOrdering = "-readable_name"
+	GetTagsV1TagsGetParamsOrderingMinusReserved     GetTagsV1TagsGetParamsOrdering = "-reserved"
+	GetTagsV1TagsGetParamsOrderingName              GetTagsV1TagsGetParamsOrdering = "name"
+	GetTagsV1TagsGetParamsOrderingReadableName      GetTagsV1TagsGetParamsOrdering = "readable_name"
+	GetTagsV1TagsGetParamsOrderingReserved          GetTagsV1TagsGetParamsOrdering = "reserved"
+)
+
 // APICompositeError defines model for APICompositeError.
 type APICompositeError struct {
 	// Detail A detailed human-readable explanation of the error.
-	Detail *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"detail"`
+	Detail *string `json:"detail"`
 
 	// Errors A list of detailed errors for individual fields.
 	Errors []APIFieldError `json:"errors"`
@@ -411,9 +508,7 @@ type APICompositeError struct {
 // APIError defines model for APIError.
 type APIError struct {
 	// Detail A detailed human-readable explanation of the error.
-	Detail *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"detail"`
+	Detail *string `json:"detail"`
 
 	// Status The HTTP status code applicable to this error.
 	Status int `json:"status"`
@@ -459,15 +554,10 @@ type APIFieldError_Loc struct {
 // AdvancedRule A request to create a new advanced rule
 type AdvancedRule struct {
 	// Action The action that the rule takes when triggered
-	Action struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleAction-Input)
-		CustomerRuleActionInput `yaml:",inline"`
-	} `json:"action"`
+	Action CustomerRuleActionInput `json:"action"`
 
 	// Description The description assigned to the rule
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"description"`
+	Description *string `json:"description"`
 
 	// Enabled Whether or not the rule is enabled
 	Enabled bool `json:"enabled"`
@@ -483,9 +573,7 @@ type AdvancedRule struct {
 	// The "header_filter" phase is responsible for modifying the HTTP headers of a response before they are sent back to the client.
 	//
 	// The "body_filter" phase is responsible for modifying the body of a response before it is sent back to the client.
-	Phase *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"phase"`
+	Phase *AdvancedRulePhase `json:"phase"`
 
 	// Source A CEL syntax expression that contains the rule's conditions. Allowed objects are: request, whois, session, response, tags, user_defined_tags, user_agent, client_data.
 	//
@@ -493,17 +581,16 @@ type AdvancedRule struct {
 	Source string `json:"source"`
 }
 
+// AdvancedRulePhase defines model for AdvancedRule.Phase.
+type AdvancedRulePhase string
+
 // AdvancedRuleDescriptor Advanced rules descriptor object
 type AdvancedRuleDescriptor struct {
 	// Attrs The object's attributes list
-	Attrs *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"attrs"`
+	Attrs *[]AdvancedRuleDescriptorAttr `json:"attrs"`
 
 	// Description The object's description
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"description"`
+	Description *string `json:"description"`
 
 	// Name The object's name
 	Name string `json:"name"`
@@ -515,9 +602,7 @@ type AdvancedRuleDescriptor struct {
 // AdvancedRuleDescriptorArg An argument of a descriptor's object
 type AdvancedRuleDescriptorArg struct {
 	// Description The argument's description
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"description"`
+	Description *string `json:"description"`
 
 	// Name The argument's name
 	Name string `json:"name"`
@@ -529,19 +614,13 @@ type AdvancedRuleDescriptorArg struct {
 // AdvancedRuleDescriptorAttr An attribute of a descriptor's object
 type AdvancedRuleDescriptorAttr struct {
 	// Args A list of arguments for the attribute
-	Args *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"args"`
+	Args *[]AdvancedRuleDescriptorArg `json:"args"`
 
 	// Description The attribute's description
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"description"`
+	Description *string `json:"description"`
 
 	// Hint The attribute's hint
-	Hint *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"hint"`
+	Hint *string `json:"hint"`
 
 	// Name The attribute's name
 	Name string `json:"name"`
@@ -552,9 +631,7 @@ type AdvancedRuleDescriptorAttr struct {
 
 // AdvancedRuleDescriptorResponse A response from a request to retrieve an advanced rules descriptor
 type AdvancedRuleDescriptorResponse struct {
-	Objects *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"objects"`
+	Objects *[]AdvancedRuleDescriptor `json:"objects"`
 
 	// Version The descriptor's version
 	Version string `json:"version"`
@@ -563,15 +640,10 @@ type AdvancedRuleDescriptorResponse struct {
 // AdvancedRuleResponse An advanced WAAP rule applied to a domain
 type AdvancedRuleResponse struct {
 	// Action The action that the rule takes when triggered
-	Action struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleAction-Output)
-		CustomerRuleActionOutput `yaml:",inline"`
-	} `json:"action"`
+	Action CustomerRuleActionOutput `json:"action"`
 
 	// Description The description assigned to the rule
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"description"`
+	Description *string `json:"description"`
 
 	// Enabled Whether or not the rule is enabled
 	Enabled bool `json:"enabled"`
@@ -590,9 +662,7 @@ type AdvancedRuleResponse struct {
 	// The "header_filter" phase is responsible for modifying the HTTP headers of a response before they are sent back to the client.
 	//
 	// The "body_filter" phase is responsible for modifying the body of a response before it is sent back to the client.
-	Phase *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"phase"`
+	Phase *AdvancedRuleResponsePhase `json:"phase"`
 
 	// Source A CEL syntax expression that contains the rule's conditions. Allowed objects are: request, whois, session, response, tags, user_defined_tags, user_agent, client_data.
 	//
@@ -600,32 +670,25 @@ type AdvancedRuleResponse struct {
 	Source string `json:"source"`
 }
 
+// AdvancedRuleResponsePhase defines model for AdvancedRuleResponse.Phase.
+type AdvancedRuleResponsePhase string
+
 // ApiDiscoverySettings Response model for the API discovery settings
 type ApiDiscoverySettings struct {
 	// DescriptionFileLocation The URL of the API description file. This will be periodically scanned if `descriptionFileScanEnabled` is enabled. Supported formats are YAML and JSON, and it must adhere to OpenAPI versions 2, 3, or 3.1.
-	DescriptionFileLocation *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"descriptionFileLocation"`
+	DescriptionFileLocation *string `json:"descriptionFileLocation"`
 
 	// DescriptionFileScanEnabled Indicates if periodic scan of the description file is enabled
-	DescriptionFileScanEnabled *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"descriptionFileScanEnabled"`
+	DescriptionFileScanEnabled *bool `json:"descriptionFileScanEnabled"`
 
 	// DescriptionFileScanIntervalHours The interval in hours for scanning the description file
-	DescriptionFileScanIntervalHours *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"descriptionFileScanIntervalHours"`
+	DescriptionFileScanIntervalHours *int `json:"descriptionFileScanIntervalHours"`
 
 	// TrafficScanEnabled Indicates if traffic scan is enabled. Traffic scan is used to discover undocumented APIs
-	TrafficScanEnabled *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"trafficScanEnabled"`
+	TrafficScanEnabled *bool `json:"trafficScanEnabled"`
 
 	// TrafficScanIntervalHours The interval in hours for scanning the traffic
-	TrafficScanIntervalHours *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"trafficScanIntervalHours"`
+	TrafficScanIntervalHours *int `json:"trafficScanIntervalHours"`
 }
 
 // ApiPathGroups Response model for the API path groups
@@ -652,10 +715,7 @@ type ApiPathResponse struct {
 	FirstDetected time.Time `json:"first_detected"`
 
 	// HttpScheme The HTTP version of the API path
-	HttpScheme struct {
-		// Embedded struct due to allOf(#/components/schemas/ApiPathHttpScheme)
-		ApiPathHttpScheme `yaml:",inline"`
-	} `json:"http_scheme"`
+	HttpScheme ApiPathHttpScheme `json:"http_scheme"`
 
 	// Id The path ID
 	Id openapi_types.UUID `json:"id"`
@@ -664,10 +724,7 @@ type ApiPathResponse struct {
 	LastDetected time.Time `json:"last_detected"`
 
 	// Method The API RESTful method
-	Method struct {
-		// Embedded struct due to allOf(#/components/schemas/ApiPathMethod)
-		ApiPathMethod `yaml:",inline"`
-	} `json:"method"`
+	Method ApiPathMethod `json:"method"`
 
 	// Path The API path, locations that are saved for resource IDs will be put in curly brackets
 	Path string `json:"path"`
@@ -676,16 +733,10 @@ type ApiPathResponse struct {
 	RequestCount int `json:"request_count"`
 
 	// Source The source of the discovered API
-	Source struct {
-		// Embedded struct due to allOf(#/components/schemas/ApiPathSource)
-		ApiPathSource `yaml:",inline"`
-	} `json:"source"`
+	Source ApiPathSource `json:"source"`
 
 	// Status The status of the discovered API path
-	Status struct {
-		// Embedded struct due to allOf(#/components/schemas/ApiPathStatus)
-		ApiPathStatus `yaml:",inline"`
-	} `json:"status"`
+	Status ApiPathStatus `json:"status"`
 
 	// Tags An array of tags associated with the API path
 	Tags []string `json:"tags"`
@@ -700,9 +751,7 @@ type ApiPathStatus string
 // ApiScanResult The result of a scan
 type ApiScanResult struct {
 	// EndTime The date and time the scan ended
-	EndTime *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"end_time"`
+	EndTime *time.Time `json:"end_time"`
 
 	// Id The scan ID
 	Id openapi_types.UUID `json:"id"`
@@ -714,16 +763,10 @@ type ApiScanResult struct {
 	StartTime time.Time `json:"start_time"`
 
 	// Status The status of the scan
-	Status struct {
-		// Embedded struct due to allOf(#/components/schemas/TaskResultStatus)
-		TaskResultStatus `yaml:",inline"`
-	} `json:"status"`
+	Status TaskResultStatus `json:"status"`
 
 	// Type The type of scan
-	Type struct {
-		// Embedded struct due to allOf(#/components/schemas/ApiScanType)
-		ApiScanType `yaml:",inline"`
-	} `json:"type"`
+	Type ApiScanType `json:"type"`
 }
 
 // ApiScanType The different types of scans that can be performed
@@ -860,18 +903,13 @@ type ClientInfo struct {
 	Features []string `json:"features"`
 
 	// Id The client ID
-	Id *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"id"`
+	Id *int `json:"id"`
 
 	// Quotas Quotas for the client
 	Quotas map[string]QuotaItem `json:"quotas"`
 
 	// Service Information about the WAAP service status
-	Service struct {
-		// Embedded struct due to allOf(#/components/schemas/Service)
-		Service `yaml:",inline"`
-	} `json:"service"`
+	Service Service `json:"service"`
 }
 
 // CommonTag Common tag details
@@ -1005,9 +1043,7 @@ type CreateInsightSilencePayload struct {
 	Comment string `json:"comment"`
 
 	// ExpireAt The date and time the silence expires in ISO 8601 format
-	ExpireAt *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"expire_at"`
+	ExpireAt *time.Time `json:"expire_at"`
 
 	// InsightType The slug of the insight type
 	InsightType string `json:"insight_type"`
@@ -1024,35 +1060,15 @@ type CustomPagePreviewResponse struct {
 
 // CustomPageSetCreate Create a custom page set
 type CustomPageSetCreate struct {
-	Block *struct {
-		// Embedded struct due to allOf(#/components/schemas/BlockPageData)
-		BlockPageData `yaml:",inline"`
-	} `json:"block"`
-	BlockCsrf *struct {
-		// Embedded struct due to allOf(#/components/schemas/BlockCsrfPageData)
-		BlockCsrfPageData `yaml:",inline"`
-	} `json:"block_csrf"`
-	Captcha *struct {
-		// Embedded struct due to allOf(#/components/schemas/CaptchaPageData)
-		CaptchaPageData `yaml:",inline"`
-	} `json:"captcha"`
-	CookieDisabled *struct {
-		// Embedded struct due to allOf(#/components/schemas/CookieDisabledPageData)
-		CookieDisabledPageData `yaml:",inline"`
-	} `json:"cookie_disabled"`
+	Block          *BlockPageData          `json:"block"`
+	BlockCsrf      *BlockCsrfPageData      `json:"block_csrf"`
+	Captcha        *CaptchaPageData        `json:"captcha"`
+	CookieDisabled *CookieDisabledPageData `json:"cookie_disabled"`
 
 	// Domains List of domain IDs that are associated with this page set
-	Domains *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"domains"`
-	Handshake *struct {
-		// Embedded struct due to allOf(#/components/schemas/HandshakePageData)
-		HandshakePageData `yaml:",inline"`
-	} `json:"handshake"`
-	JavascriptDisabled *struct {
-		// Embedded struct due to allOf(#/components/schemas/JavascriptDisabledPageData)
-		JavascriptDisabledPageData `yaml:",inline"`
-	} `json:"javascript_disabled"`
+	Domains            *[]int                      `json:"domains"`
+	Handshake          *HandshakePageData          `json:"handshake"`
+	JavascriptDisabled *JavascriptDisabledPageData `json:"javascript_disabled"`
 
 	// Name Name of the custom page set
 	Name string `json:"name"`
@@ -1060,38 +1076,18 @@ type CustomPageSetCreate struct {
 
 // CustomPageSetResponse defines model for CustomPageSetResponse.
 type CustomPageSetResponse struct {
-	Block *struct {
-		// Embedded struct due to allOf(#/components/schemas/BlockPageData)
-		BlockPageData `yaml:",inline"`
-	} `json:"block"`
-	BlockCsrf *struct {
-		// Embedded struct due to allOf(#/components/schemas/BlockCsrfPageData)
-		BlockCsrfPageData `yaml:",inline"`
-	} `json:"block_csrf"`
-	Captcha *struct {
-		// Embedded struct due to allOf(#/components/schemas/CaptchaPageData)
-		CaptchaPageData `yaml:",inline"`
-	} `json:"captcha"`
-	CookieDisabled *struct {
-		// Embedded struct due to allOf(#/components/schemas/CookieDisabledPageData)
-		CookieDisabledPageData `yaml:",inline"`
-	} `json:"cookie_disabled"`
+	Block          *BlockPageData          `json:"block"`
+	BlockCsrf      *BlockCsrfPageData      `json:"block_csrf"`
+	Captcha        *CaptchaPageData        `json:"captcha"`
+	CookieDisabled *CookieDisabledPageData `json:"cookie_disabled"`
 
 	// Domains List of domain IDs that are associated with this page set
-	Domains *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"domains"`
-	Handshake *struct {
-		// Embedded struct due to allOf(#/components/schemas/HandshakePageData)
-		HandshakePageData `yaml:",inline"`
-	} `json:"handshake"`
+	Domains   *[]int             `json:"domains"`
+	Handshake *HandshakePageData `json:"handshake"`
 
 	// Id The ID of the custom page set
-	Id                 int `json:"id"`
-	JavascriptDisabled *struct {
-		// Embedded struct due to allOf(#/components/schemas/JavascriptDisabledPageData)
-		JavascriptDisabledPageData `yaml:",inline"`
-	} `json:"javascript_disabled"`
+	Id                 int                         `json:"id"`
+	JavascriptDisabled *JavascriptDisabledPageData `json:"javascript_disabled"`
 
 	// Name Name of the custom page set
 	Name string `json:"name"`
@@ -1099,57 +1095,30 @@ type CustomPageSetResponse struct {
 
 // CustomPageSetUpdate Update a custom page set
 type CustomPageSetUpdate struct {
-	Block *struct {
-		// Embedded struct due to allOf(#/components/schemas/BlockPageData)
-		BlockPageData `yaml:",inline"`
-	} `json:"block"`
-	BlockCsrf *struct {
-		// Embedded struct due to allOf(#/components/schemas/BlockCsrfPageData)
-		BlockCsrfPageData `yaml:",inline"`
-	} `json:"block_csrf"`
-	Captcha *struct {
-		// Embedded struct due to allOf(#/components/schemas/CaptchaPageData)
-		CaptchaPageData `yaml:",inline"`
-	} `json:"captcha"`
-	CookieDisabled *struct {
-		// Embedded struct due to allOf(#/components/schemas/CookieDisabledPageData)
-		CookieDisabledPageData `yaml:",inline"`
-	} `json:"cookie_disabled"`
+	Block          *BlockPageData          `json:"block"`
+	BlockCsrf      *BlockCsrfPageData      `json:"block_csrf"`
+	Captcha        *CaptchaPageData        `json:"captcha"`
+	CookieDisabled *CookieDisabledPageData `json:"cookie_disabled"`
 
 	// Domains List of domain IDs that are associated with this page set
-	Domains *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"domains"`
-	Handshake *struct {
-		// Embedded struct due to allOf(#/components/schemas/HandshakePageData)
-		HandshakePageData `yaml:",inline"`
-	} `json:"handshake"`
-	JavascriptDisabled *struct {
-		// Embedded struct due to allOf(#/components/schemas/JavascriptDisabledPageData)
-		JavascriptDisabledPageData `yaml:",inline"`
-	} `json:"javascript_disabled"`
+	Domains            *[]int                      `json:"domains"`
+	Handshake          *HandshakePageData          `json:"handshake"`
+	JavascriptDisabled *JavascriptDisabledPageData `json:"javascript_disabled"`
 
 	// Name Name of the custom page set
-	Name *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"name"`
+	Name *string `json:"name"`
 }
 
 // CustomRule A request to create a new WAAP rule
 type CustomRule struct {
 	// Action The action that the rule takes when triggered
-	Action struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleAction-Input)
-		CustomerRuleActionInput `yaml:",inline"`
-	} `json:"action"`
+	Action CustomerRuleActionInput `json:"action"`
 
 	// Conditions The conditions required for the WAAP engine to trigger the rule. Rules may have between 1 and 5 conditions. All conditions must pass for the rule to trigger
 	Conditions []CustomRuleConditionInput `json:"conditions"`
 
 	// Description The description assigned to the rule
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"description"`
+	Description *string `json:"description"`
 
 	// Enabled Whether or not the rule is enabled
 	Enabled bool `json:"enabled"`
@@ -1160,171 +1129,58 @@ type CustomRule struct {
 
 // CustomRuleConditionInput The criteria of an incoming web request and the models of the various values those criteria can take
 type CustomRuleConditionInput struct {
-	ContentType *struct {
-		// Embedded struct due to allOf(#/components/schemas/ContentTypeCondition)
-		ContentTypeCondition `yaml:",inline"`
-	} `json:"content_type"`
-	Country *struct {
-		// Embedded struct due to allOf(#/components/schemas/CountryCondition)
-		CountryCondition `yaml:",inline"`
-	} `json:"country"`
-	FileExtension *struct {
-		// Embedded struct due to allOf(#/components/schemas/FileExtensionCondition)
-		FileExtensionCondition `yaml:",inline"`
-	} `json:"file_extension"`
-	Header *struct {
-		// Embedded struct due to allOf(#/components/schemas/HeaderCondition)
-		HeaderCondition `yaml:",inline"`
-	} `json:"header"`
-	HeaderExists *struct {
-		// Embedded struct due to allOf(#/components/schemas/HeaderExistsCondition)
-		HeaderExistsCondition `yaml:",inline"`
-	} `json:"header_exists"`
-	HttpMethod *struct {
-		// Embedded struct due to allOf(#/components/schemas/HttpMethodCondition)
-		HttpMethodCondition `yaml:",inline"`
-	} `json:"http_method"`
-	Ip *struct {
-		// Embedded struct due to allOf(#/components/schemas/IpCondition)
-		IpCondition `yaml:",inline"`
-	} `json:"ip"`
-	IpRange *struct {
-		// Embedded struct due to allOf(#/components/schemas/IpRangeCondition)
-		IpRangeCondition `yaml:",inline"`
-	} `json:"ip_range"`
-	Organization *struct {
-		// Embedded struct due to allOf(#/components/schemas/OrganizationCondition)
-		OrganizationCondition `yaml:",inline"`
-	} `json:"organization"`
-	OwnerTypes *struct {
-		// Embedded struct due to allOf(#/components/schemas/OwnerTypesCondition)
-		OwnerTypesCondition `yaml:",inline"`
-	} `json:"owner_types"`
-	RequestRate *struct {
-		// Embedded struct due to allOf(#/components/schemas/RequestRateCondition)
-		RequestRateCondition `yaml:",inline"`
-	} `json:"request_rate"`
-	ResponseHeader *struct {
-		// Embedded struct due to allOf(#/components/schemas/ResponseHeaderCondition)
-		ResponseHeaderCondition `yaml:",inline"`
-	} `json:"response_header"`
-	ResponseHeaderExists *struct {
-		// Embedded struct due to allOf(#/components/schemas/ResponseHeaderExistsCondition)
-		ResponseHeaderExistsCondition `yaml:",inline"`
-	} `json:"response_header_exists"`
-	SessionRequestCount *struct {
-		// Embedded struct due to allOf(#/components/schemas/SessionRequestCountCondition)
-		SessionRequestCountCondition `yaml:",inline"`
-	} `json:"session_request_count"`
-	Tags *struct {
-		// Embedded struct due to allOf(#/components/schemas/TagsCondition)
-		TagsCondition `yaml:",inline"`
-	} `json:"tags"`
-	Url *struct {
-		// Embedded struct due to allOf(#/components/schemas/UrlCondition)
-		UrlCondition `yaml:",inline"`
-	} `json:"url"`
-	UserAgent *struct {
-		// Embedded struct due to allOf(#/components/schemas/UserAgentCondition)
-		UserAgentCondition `yaml:",inline"`
-	} `json:"user_agent"`
-	UserDefinedTags *struct {
-		// Embedded struct due to allOf(#/components/schemas/UserDefinedTagsCondition)
-		UserDefinedTagsCondition `yaml:",inline"`
-	} `json:"user_defined_tags"`
+	ContentType          *ContentTypeCondition          `json:"content_type"`
+	Country              *CountryCondition              `json:"country"`
+	FileExtension        *FileExtensionCondition        `json:"file_extension"`
+	Header               *HeaderCondition               `json:"header"`
+	HeaderExists         *HeaderExistsCondition         `json:"header_exists"`
+	HttpMethod           *HttpMethodCondition           `json:"http_method"`
+	Ip                   *IpCondition                   `json:"ip"`
+	IpRange              *IpRangeCondition              `json:"ip_range"`
+	Organization         *OrganizationCondition         `json:"organization"`
+	OwnerTypes           *OwnerTypesCondition           `json:"owner_types"`
+	RequestRate          *RequestRateCondition          `json:"request_rate"`
+	ResponseHeader       *ResponseHeaderCondition       `json:"response_header"`
+	ResponseHeaderExists *ResponseHeaderExistsCondition `json:"response_header_exists"`
+	SessionRequestCount  *SessionRequestCountCondition  `json:"session_request_count"`
+	Tags                 *TagsCondition                 `json:"tags"`
+	Url                  *UrlCondition                  `json:"url"`
+	UserAgent            *UserAgentCondition            `json:"user_agent"`
+	UserDefinedTags      *UserDefinedTagsCondition      `json:"user_defined_tags"`
 }
 
 // CustomRuleConditionOutput The criteria of an incoming web request and the models of the various values those criteria can take
 type CustomRuleConditionOutput struct {
-	ContentType *struct {
-		// Embedded struct due to allOf(#/components/schemas/ContentTypeCondition)
-		ContentTypeCondition `yaml:",inline"`
-	} `json:"content_type"`
-	Country *struct {
-		// Embedded struct due to allOf(#/components/schemas/CountryCondition)
-		CountryCondition `yaml:",inline"`
-	} `json:"country"`
-	FileExtension *struct {
-		// Embedded struct due to allOf(#/components/schemas/FileExtensionCondition)
-		FileExtensionCondition `yaml:",inline"`
-	} `json:"file_extension"`
-	Header *struct {
-		// Embedded struct due to allOf(#/components/schemas/HeaderCondition)
-		HeaderCondition `yaml:",inline"`
-	} `json:"header"`
-	HeaderExists *struct {
-		// Embedded struct due to allOf(#/components/schemas/HeaderExistsCondition)
-		HeaderExistsCondition `yaml:",inline"`
-	} `json:"header_exists"`
-	HttpMethod *struct {
-		// Embedded struct due to allOf(#/components/schemas/HttpMethodCondition)
-		HttpMethodCondition `yaml:",inline"`
-	} `json:"http_method"`
-	Ip *struct {
-		// Embedded struct due to allOf(#/components/schemas/IpCondition)
-		IpCondition `yaml:",inline"`
-	} `json:"ip"`
-	IpRange *struct {
-		// Embedded struct due to allOf(#/components/schemas/IpRangeCondition)
-		IpRangeCondition `yaml:",inline"`
-	} `json:"ip_range"`
-	Organization *struct {
-		// Embedded struct due to allOf(#/components/schemas/OrganizationCondition)
-		OrganizationCondition `yaml:",inline"`
-	} `json:"organization"`
-	OwnerTypes *struct {
-		// Embedded struct due to allOf(#/components/schemas/OwnerTypesCondition)
-		OwnerTypesCondition `yaml:",inline"`
-	} `json:"owner_types"`
-	RequestRate *struct {
-		// Embedded struct due to allOf(#/components/schemas/RequestRateCondition)
-		RequestRateCondition `yaml:",inline"`
-	} `json:"request_rate"`
-	ResponseHeader *struct {
-		// Embedded struct due to allOf(#/components/schemas/ResponseHeaderCondition)
-		ResponseHeaderCondition `yaml:",inline"`
-	} `json:"response_header"`
-	ResponseHeaderExists *struct {
-		// Embedded struct due to allOf(#/components/schemas/ResponseHeaderExistsCondition)
-		ResponseHeaderExistsCondition `yaml:",inline"`
-	} `json:"response_header_exists"`
-	SessionRequestCount *struct {
-		// Embedded struct due to allOf(#/components/schemas/SessionRequestCountCondition)
-		SessionRequestCountCondition `yaml:",inline"`
-	} `json:"session_request_count"`
-	Tags *struct {
-		// Embedded struct due to allOf(#/components/schemas/TagsCondition)
-		TagsCondition `yaml:",inline"`
-	} `json:"tags"`
-	Url *struct {
-		// Embedded struct due to allOf(#/components/schemas/UrlCondition)
-		UrlCondition `yaml:",inline"`
-	} `json:"url"`
-	UserAgent *struct {
-		// Embedded struct due to allOf(#/components/schemas/UserAgentCondition)
-		UserAgentCondition `yaml:",inline"`
-	} `json:"user_agent"`
-	UserDefinedTags *struct {
-		// Embedded struct due to allOf(#/components/schemas/UserDefinedTagsCondition)
-		UserDefinedTagsCondition `yaml:",inline"`
-	} `json:"user_defined_tags"`
+	ContentType          *ContentTypeCondition          `json:"content_type"`
+	Country              *CountryCondition              `json:"country"`
+	FileExtension        *FileExtensionCondition        `json:"file_extension"`
+	Header               *HeaderCondition               `json:"header"`
+	HeaderExists         *HeaderExistsCondition         `json:"header_exists"`
+	HttpMethod           *HttpMethodCondition           `json:"http_method"`
+	Ip                   *IpCondition                   `json:"ip"`
+	IpRange              *IpRangeCondition              `json:"ip_range"`
+	Organization         *OrganizationCondition         `json:"organization"`
+	OwnerTypes           *OwnerTypesCondition           `json:"owner_types"`
+	RequestRate          *RequestRateCondition          `json:"request_rate"`
+	ResponseHeader       *ResponseHeaderCondition       `json:"response_header"`
+	ResponseHeaderExists *ResponseHeaderExistsCondition `json:"response_header_exists"`
+	SessionRequestCount  *SessionRequestCountCondition  `json:"session_request_count"`
+	Tags                 *TagsCondition                 `json:"tags"`
+	Url                  *UrlCondition                  `json:"url"`
+	UserAgent            *UserAgentCondition            `json:"user_agent"`
+	UserDefinedTags      *UserDefinedTagsCondition      `json:"user_defined_tags"`
 }
 
 // CustomRuleResponse An WAAP rule applied to a domain
 type CustomRuleResponse struct {
 	// Action The action that the rule takes when triggered
-	Action struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleAction-Output)
-		CustomerRuleActionOutput `yaml:",inline"`
-	} `json:"action"`
+	Action CustomerRuleActionOutput `json:"action"`
 
 	// Conditions The conditions required for the WAAP engine to trigger the rule. Rules may have between 1 and 5 conditions. All conditions must pass for the rule to trigger
 	Conditions []CustomRuleConditionOutput `json:"conditions"`
 
 	// Description The description assigned to the rule
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"description"`
+	Description *string `json:"description"`
 
 	// Enabled Whether or not the rule is enabled
 	Enabled bool `json:"enabled"`
@@ -1338,58 +1194,22 @@ type CustomRuleResponse struct {
 
 // CustomerRuleActionInput The action that a WAAP rule takes when triggered
 type CustomerRuleActionInput struct {
-	Allow *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleAllowAction)
-		RuleAllowAction `yaml:",inline"`
-	} `json:"allow"`
-	Block *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleBlockAction)
-		RuleBlockAction `yaml:",inline"`
-	} `json:"block"`
-	Captcha *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleCaptchaAction)
-		RuleCaptchaAction `yaml:",inline"`
-	} `json:"captcha"`
-	Handshake *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleHandshakeAction)
-		RuleHandshakeAction `yaml:",inline"`
-	} `json:"handshake"`
-	Monitor *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleMonitorAction)
-		RuleMonitorAction `yaml:",inline"`
-	} `json:"monitor"`
-	Tag *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleTagAction)
-		RuleTagAction `yaml:",inline"`
-	} `json:"tag"`
+	Allow     *RuleAllowAction     `json:"allow"`
+	Block     *RuleBlockAction     `json:"block"`
+	Captcha   *RuleCaptchaAction   `json:"captcha"`
+	Handshake *RuleHandshakeAction `json:"handshake"`
+	Monitor   *RuleMonitorAction   `json:"monitor"`
+	Tag       *RuleTagAction       `json:"tag"`
 }
 
 // CustomerRuleActionOutput The action that a WAAP rule takes when triggered
 type CustomerRuleActionOutput struct {
-	Allow *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleAllowAction)
-		RuleAllowAction `yaml:",inline"`
-	} `json:"allow"`
-	Block *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleBlockAction)
-		RuleBlockAction `yaml:",inline"`
-	} `json:"block"`
-	Captcha *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleCaptchaAction)
-		RuleCaptchaAction `yaml:",inline"`
-	} `json:"captcha"`
-	Handshake *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleHandshakeAction)
-		RuleHandshakeAction `yaml:",inline"`
-	} `json:"handshake"`
-	Monitor *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleMonitorAction)
-		RuleMonitorAction `yaml:",inline"`
-	} `json:"monitor"`
-	Tag *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleTagAction)
-		RuleTagAction `yaml:",inline"`
-	} `json:"tag"`
+	Allow     *RuleAllowAction     `json:"allow"`
+	Block     *RuleBlockAction     `json:"block"`
+	Captcha   *RuleCaptchaAction   `json:"captcha"`
+	Handshake *RuleHandshakeAction `json:"handshake"`
+	Monitor   *RuleMonitorAction   `json:"monitor"`
+	Tag       *RuleTagAction       `json:"tag"`
 }
 
 // CustomerRuleState defines model for CustomerRuleState.
@@ -1398,9 +1218,7 @@ type CustomerRuleState string
 // DdosAttack defines model for DdosAttack.
 type DdosAttack struct {
 	// EndTime End time of DDoS attack
-	EndTime *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"end_time"`
+	EndTime *time.Time `json:"end_time"`
 
 	// StartTime Start time of DDoS attack
 	StartTime *time.Time `json:"start_time,omitempty"`
@@ -1428,9 +1246,7 @@ type DdosInfoType string
 type DetailedDomainResponse struct {
 	// CreatedAt The date and time the domain was created in ISO 8601 format
 	CreatedAt     time.Time `json:"created_at"`
-	CustomPageSet *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"custom_page_set"`
+	CustomPageSet *int      `json:"custom_page_set"`
 
 	// Id The domain ID
 	Id int `json:"id"`
@@ -1439,9 +1255,7 @@ type DetailedDomainResponse struct {
 	Name string `json:"name"`
 
 	// Quotas Domain level quotas
-	Quotas *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"quotas"`
+	Quotas *map[string]QuotaItem `json:"quotas"`
 
 	// Status The different statuses a domain can have
 	Status DomainStatus `json:"status"`
@@ -1462,10 +1276,7 @@ type DomainDdosSettings struct {
 // DomainPolicy Represents a configurable WAAP security rule, also known as a policy.
 type DomainPolicy struct {
 	// Action Specifies the action taken by the WAAP upon rule activation
-	Action struct {
-		// Embedded struct due to allOf(#/components/schemas/PolicyAction)
-		PolicyAction `yaml:",inline"`
-	} `json:"action"`
+	Action PolicyAction `json:"action"`
 
 	// Description Detailed description of the security rule
 	Description string `json:"description"`
@@ -1522,18 +1333,13 @@ type FileExtensionCondition struct {
 // FirewallRule defines model for FirewallRule.
 type FirewallRule struct {
 	// Action The action that the rule takes when triggered
-	Action struct {
-		// Embedded struct due to allOf(#/components/schemas/FirewallRuleAction-Input)
-		FirewallRuleActionInput `yaml:",inline"`
-	} `json:"action"`
+	Action FirewallRuleActionInput `json:"action"`
 
 	// Conditions The condition required for the WAAP engine to trigger the rule.
 	Conditions []FirewallRuleCondition `json:"conditions"`
 
 	// Description The description assigned to the rule
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"description"`
+	Description *string `json:"description"`
 
 	// Enabled Whether or not the rule is enabled
 	Enabled bool `json:"enabled"`
@@ -1544,55 +1350,32 @@ type FirewallRule struct {
 
 // FirewallRuleActionInput The action that a firewall rule takes when triggered
 type FirewallRuleActionInput struct {
-	Allow *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleAllowAction)
-		RuleAllowAction `yaml:",inline"`
-	} `json:"allow"`
-	Block *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleBlockAction)
-		RuleBlockAction `yaml:",inline"`
-	} `json:"block"`
+	Allow *RuleAllowAction `json:"allow"`
+	Block *RuleBlockAction `json:"block"`
 }
 
 // FirewallRuleActionOutput The action that a firewall rule takes when triggered
 type FirewallRuleActionOutput struct {
-	Allow *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleAllowAction)
-		RuleAllowAction `yaml:",inline"`
-	} `json:"allow"`
-	Block *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleBlockAction)
-		RuleBlockAction `yaml:",inline"`
-	} `json:"block"`
+	Allow *RuleAllowAction `json:"allow"`
+	Block *RuleBlockAction `json:"block"`
 }
 
 // FirewallRuleCondition The criteria of an incoming web request and the models of the various values those criteria can take
 type FirewallRuleCondition struct {
-	Ip *struct {
-		// Embedded struct due to allOf(#/components/schemas/IpCondition)
-		IpCondition `yaml:",inline"`
-	} `json:"ip"`
-	IpRange *struct {
-		// Embedded struct due to allOf(#/components/schemas/IpRangeCondition)
-		IpRangeCondition `yaml:",inline"`
-	} `json:"ip_range"`
+	Ip      *IpCondition      `json:"ip"`
+	IpRange *IpRangeCondition `json:"ip_range"`
 }
 
 // FirewallRuleResponse defines model for FirewallRuleResponse.
 type FirewallRuleResponse struct {
 	// Action The action that the rule takes when triggered
-	Action struct {
-		// Embedded struct due to allOf(#/components/schemas/FirewallRuleAction-Output)
-		FirewallRuleActionOutput `yaml:",inline"`
-	} `json:"action"`
+	Action FirewallRuleActionOutput `json:"action"`
 
 	// Conditions The condition required for the WAAP engine to trigger the rule.
 	Conditions []FirewallRuleCondition `json:"conditions"`
 
 	// Description The description assigned to the rule
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"description"`
+	Description *string `json:"description"`
 
 	// Enabled Whether or not the rule is enabled
 	Enabled bool `json:"enabled"`
@@ -1657,10 +1440,7 @@ type HeaderExistsCondition struct {
 // HttpMethodCondition Match the incoming HTTP method
 type HttpMethodCondition struct {
 	// HttpMethod HTTP methods of a request
-	HttpMethod struct {
-		// Embedded struct due to allOf(#/components/schemas/HTTPMethod)
-		HTTPMethod `yaml:",inline"`
-	} `json:"http_method"`
+	HttpMethod HTTPMethod `json:"http_method"`
 
 	// Negation Whether or not to apply a boolean NOT operation to the rule's condition
 	Negation *bool `json:"negation,omitempty"`
@@ -1693,10 +1473,7 @@ type Insight struct {
 	Recommendation string `json:"recommendation"`
 
 	// Status The status of the insight
-	Status struct {
-		// Embedded struct due to allOf(#/components/schemas/InsightStatus)
-		InsightStatus `yaml:",inline"`
-	} `json:"status"`
+	Status InsightStatus `json:"status"`
 }
 
 // InsightSilence defines model for InsightSilence.
@@ -1708,9 +1485,7 @@ type InsightSilence struct {
 	Comment string `json:"comment"`
 
 	// ExpireAt The date and time the silence expires in ISO 8601 format
-	ExpireAt *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"expire_at"`
+	ExpireAt *time.Time `json:"expire_at"`
 
 	// Id A generated unique identifier for the silence
 	Id openapi_types.UUID `json:"id"`
@@ -1805,10 +1580,7 @@ type IpInfo struct {
 	Tags []string `json:"tags"`
 
 	// Whois The WHOIS information for the IP address
-	Whois struct {
-		// Embedded struct due to allOf(#/components/schemas/WhoisInfo)
-		WhoisInfo `yaml:",inline"`
-	} `json:"whois"`
+	Whois WhoisInfo `json:"whois"`
 }
 
 // IpInfoRiskScore The risk score of the IP address
@@ -2171,21 +1943,11 @@ type PolicyMode struct {
 
 // PreviewCustomPage defines model for PreviewCustomPage.
 type PreviewCustomPage struct {
-	Error *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"error"`
-	Header *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"header"`
-	Logo *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"logo"`
-	Text *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"text"`
-	Title *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"title"`
+	Error  *string `json:"error"`
+	Header *string `json:"header"`
+	Logo   *string `json:"logo"`
+	Text   *string `json:"text"`
+	Title  *string `json:"title"`
 }
 
 // QuotaItem defines model for QuotaItem.
@@ -2275,10 +2037,7 @@ type RequestDetails struct {
 	TrafficTypes []string `json:"traffic_types"`
 
 	// UserAgent User agent
-	UserAgent struct {
-		// Embedded struct due to allOf(#/components/schemas/UserAgent)
-		UserAgent `yaml:",inline"`
-	} `json:"user_agent"`
+	UserAgent UserAgent `json:"user_agent"`
 }
 
 // RequestDetailsResult The result of a request
@@ -2287,14 +2046,10 @@ type RequestDetailsResult string
 // RequestRateCondition Match the rate at which requests come in that match certain conditions
 type RequestRateCondition struct {
 	// HttpMethods Possible HTTP request methods that can trigger a request rate condition
-	HttpMethods *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"http_methods"`
+	HttpMethods *[]HTTPMethod `json:"http_methods"`
 
 	// Ips A list of source IPs that can trigger a request rate condition
-	Ips *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"ips"`
+	Ips *[]RequestRateCondition_Ips_Item `json:"ips"`
 
 	// Negation Whether or not to apply a boolean NOT operation to the rule's condition
 	Negation *bool `json:"negation,omitempty"`
@@ -2309,9 +2064,18 @@ type RequestRateCondition struct {
 	Time int `json:"time"`
 
 	// UserDefinedTag A user-defined tag that can be included in incoming requests and used to trigger a request rate condition
-	UserDefinedTag *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"user_defined_tag"`
+	UserDefinedTag *string `json:"user_defined_tag"`
+}
+
+// RequestRateConditionIps0 defines model for .
+type RequestRateConditionIps0 = string
+
+// RequestRateConditionIps1 defines model for .
+type RequestRateConditionIps1 = string
+
+// RequestRateCondition_Ips_Item defines model for RequestRateCondition.ips.Item.
+type RequestRateCondition_Ips_Item struct {
+	union json.RawMessage
 }
 
 // RequestSummary Request summary used when displaying a list of requests
@@ -2408,15 +2172,10 @@ type RuleAllowAction = map[string]interface{}
 // RuleBlockAction WAAP block action behavior could be configured with response status code and action duration.
 type RuleBlockAction struct {
 	// ActionDuration How long a rule's block action will apply to subsequent requests. Can be specified in seconds or by using a numeral followed by 's', 'm', 'h', or 'd' to represent time format (seconds, minutes, hours, or days)
-	ActionDuration *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"action_duration"`
+	ActionDuration *string `json:"action_duration"`
 
 	// StatusCode A custom HTTP status code that the WAAP returns if a rule blocks a request
-	StatusCode *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleBlockStatusCode)
-		RuleBlockStatusCode `yaml:",inline"`
-	} `json:"status_code"`
+	StatusCode *RuleBlockStatusCode `json:"status_code"`
 }
 
 // RuleBlockStatusCode Designates the HTTP status code to deliver when a request is blocked.
@@ -2458,10 +2217,8 @@ type RuleSet struct {
 	Name string `json:"name"`
 
 	// ResourceSlug The resource slug associated with the rule set.
-	ResourceSlug *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"resource_slug"`
-	Rules *[]DomainPolicy `json:"rules,omitempty"`
+	ResourceSlug *string         `json:"resource_slug"`
+	Rules        *[]DomainPolicy `json:"rules,omitempty"`
 
 	// Tags Collection of tags associated with the rule set.
 	Tags []AppModelsPoliciesTag `json:"tags"`
@@ -2506,23 +2263,17 @@ type StatisticItem struct {
 // StatisticsSeries Response model for the statistics series
 type StatisticsSeries struct {
 	// TotalBytes Will be returned if `total_bytes` is requested in the metrics parameter
-	TotalBytes *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"total_bytes"`
+	TotalBytes *[]StatisticItem `json:"total_bytes"`
 
 	// TotalRequests Will be included if `total_requests` is requested in the metrics parameter
-	TotalRequests *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"total_requests"`
+	TotalRequests *[]StatisticItem `json:"total_requests"`
 }
 
 // SummaryDomainResponse Represents a WAAP domain when getting a list of domains.
 type SummaryDomainResponse struct {
 	// CreatedAt The date and time the domain was created in ISO 8601 format
 	CreatedAt     time.Time `json:"created_at"`
-	CustomPageSet *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"custom_page_set"`
+	CustomPageSet *int      `json:"custom_page_set"`
 
 	// Id The domain ID
 	Id int `json:"id"`
@@ -2672,25 +2423,16 @@ type TrafficType string
 // UpdateAdvancedRule A request to update an advanced WAAP rule
 type UpdateAdvancedRule struct {
 	// Action The action that the rule takes when triggered
-	Action *struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleAction-Input)
-		CustomerRuleActionInput `yaml:",inline"`
-	} `json:"action"`
+	Action *CustomerRuleActionInput `json:"action"`
 
 	// Description The description assigned to the rule
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"description"`
+	Description *string `json:"description"`
 
 	// Enabled Whether or not the rule is enabled
-	Enabled *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"enabled"`
+	Enabled *bool `json:"enabled"`
 
 	// Name The name assigned to the rule
-	Name *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"name"`
+	Name *string `json:"name"`
 
 	// Phase The WAAP request/response phase for applying the rule.
 	//
@@ -2700,44 +2442,33 @@ type UpdateAdvancedRule struct {
 	// The "header_filter" phase is responsible for modifying the HTTP headers of a response before they are sent back to the client.
 	//
 	// The "body_filter" phase is responsible for modifying the body of a response before it is sent back to the client.
-	Phase *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"phase"`
+	Phase *UpdateAdvancedRulePhase `json:"phase"`
 
 	// Source A CEL syntax expression that contains the rule's conditions. Allowed objects are: request, whois, session, response, tags, user_defined_tags, user_agent, client_data.
 	//
 	// More info can be found here: https://gcore.com/docs/waap/waap-rules/advanced-rules
-	Source *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"source"`
+	Source *string `json:"source"`
 }
+
+// UpdateAdvancedRulePhase defines model for UpdateAdvancedRule.Phase.
+type UpdateAdvancedRulePhase string
 
 // UpdateApiDiscoverySettings Request model for updating the API discovery settings
 type UpdateApiDiscoverySettings struct {
 	// DescriptionFileLocation The URL of the API description file. This will be periodically scanned if `descriptionFileScanEnabled` is enabled. Supported formats are YAML and JSON, and it must adhere to OpenAPI versions 2, 3, or 3.1.
-	DescriptionFileLocation *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"descriptionFileLocation"`
+	DescriptionFileLocation *string `json:"descriptionFileLocation"`
 
 	// DescriptionFileScanEnabled Indicates if periodic scan of the description file is enabled
-	DescriptionFileScanEnabled *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"descriptionFileScanEnabled"`
+	DescriptionFileScanEnabled *bool `json:"descriptionFileScanEnabled"`
 
 	// DescriptionFileScanIntervalHours The interval in hours for scanning the description file
-	DescriptionFileScanIntervalHours *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"descriptionFileScanIntervalHours"`
+	DescriptionFileScanIntervalHours *int `json:"descriptionFileScanIntervalHours"`
 
 	// TrafficScanEnabled Indicates if traffic scan is enabled
-	TrafficScanEnabled *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"trafficScanEnabled"`
+	TrafficScanEnabled *bool `json:"trafficScanEnabled"`
 
 	// TrafficScanIntervalHours The interval in hours for scanning the traffic
-	TrafficScanIntervalHours *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"trafficScanIntervalHours"`
+	TrafficScanIntervalHours *int `json:"trafficScanIntervalHours"`
 }
 
 // UpdateApiPath Request model for updating an API path
@@ -2749,10 +2480,7 @@ type UpdateApiPath struct {
 	Path *string `json:"path,omitempty"`
 
 	// Status The status of the discovered API path
-	Status *struct {
-		// Embedded struct due to allOf(#/components/schemas/ApiPathStatus)
-		ApiPathStatus `yaml:",inline"`
-	} `json:"status,omitempty"`
+	Status *ApiPathStatus `json:"status,omitempty"`
 
 	// Tags An array of tags associated with the API path
 	Tags *[]string `json:"tags,omitempty"`
@@ -2761,39 +2489,25 @@ type UpdateApiPath struct {
 // UpdateCustomRule A request to update a WAAP rule
 type UpdateCustomRule struct {
 	// Action The action that the rule takes when triggered
-	Action *struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleAction-Input)
-		CustomerRuleActionInput `yaml:",inline"`
-	} `json:"action"`
+	Action *CustomerRuleActionInput `json:"action"`
 
 	// Conditions The conditions required for the WAAP engine to trigger the rule. Rules may have between 1 and 5 conditions. All conditions must pass for the rule to trigger
-	Conditions *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"conditions"`
+	Conditions *[]CustomRuleConditionInput `json:"conditions"`
 
 	// Description The description assigned to the rule
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"description"`
+	Description *string `json:"description"`
 
 	// Enabled Whether or not the rule is enabled
-	Enabled *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"enabled"`
+	Enabled *bool `json:"enabled"`
 
 	// Name The name assigned to the rule
-	Name *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"name"`
+	Name *string `json:"name"`
 }
 
 // UpdateDomain defines model for UpdateDomain.
 type UpdateDomain struct {
 	// Status The current status of the domain
-	Status *struct {
-		// Embedded struct due to allOf(#/components/schemas/DomainUpdateStatus)
-		DomainUpdateStatus `yaml:",inline"`
-	} `json:"status,omitempty"`
+	Status *DomainUpdateStatus `json:"status,omitempty"`
 }
 
 // UpdateDomainDdosSettings Editable DDoS settings for a domain.
@@ -2807,52 +2521,32 @@ type UpdateDomainDdosSettings struct {
 
 // UpdateDomainSettings Represents the editable settings for a domain.
 type UpdateDomainSettings struct {
-	Api *struct {
-		// Embedded struct due to allOf(#/components/schemas/app__models__domain_settings__UpdateApiUrls)
-		AppModelsDomainSettingsUpdateApiUrls `yaml:",inline"`
-	} `json:"api,omitempty"`
-	Ddos *struct {
-		// Embedded struct due to allOf(#/components/schemas/UpdateDomainDdosSettings)
-		UpdateDomainDdosSettings `yaml:",inline"`
-	} `json:"ddos,omitempty"`
+	Api  *AppModelsDomainSettingsUpdateApiUrls `json:"api,omitempty"`
+	Ddos *UpdateDomainDdosSettings             `json:"ddos,omitempty"`
 }
 
 // UpdateFirewallRule defines model for UpdateFirewallRule.
 type UpdateFirewallRule struct {
 	// Action The action that the rule takes when triggered
-	Action *struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleAction-Input)
-		CustomerRuleActionInput `yaml:",inline"`
-	} `json:"action"`
+	Action *CustomerRuleActionInput `json:"action"`
 
 	// Conditions The condition required for the WAAP engine to trigger the rule.
-	Conditions *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"conditions"`
+	Conditions *[]FirewallRuleCondition `json:"conditions"`
 
 	// Description The description assigned to the rule
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"description"`
+	Description *string `json:"description"`
 
 	// Enabled Whether or not the rule is enabled
-	Enabled *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"enabled"`
+	Enabled *bool `json:"enabled"`
 
 	// Name The name assigned to the rule
-	Name *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"name"`
+	Name *string `json:"name"`
 }
 
 // UpdateInsightPayload defines model for UpdateInsightPayload.
 type UpdateInsightPayload struct {
 	// Status The status of the insight
-	Status struct {
-		// Embedded struct due to allOf(#/components/schemas/InsightStatus)
-		InsightStatus `yaml:",inline"`
-	} `json:"status"`
+	Status InsightStatus `json:"status"`
 }
 
 // UpdateInsightSilencePayload defines model for UpdateInsightSilencePayload.
@@ -2864,9 +2558,7 @@ type UpdateInsightSilencePayload struct {
 	Comment string `json:"comment"`
 
 	// ExpireAt The date and time the silence expires in ISO 8601 format
-	ExpireAt *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"expire_at"`
+	ExpireAt *time.Time `json:"expire_at"`
 
 	// Labels A hash table of label names and values that apply to the insight silence
 	Labels *map[string]string `json:"labels,omitempty"`
@@ -2950,64 +2642,40 @@ type UserDefinedTagsCondition struct {
 // WhoisInfo defines model for WhoisInfo.
 type WhoisInfo struct {
 	// AbuseMail The abuse mail
-	AbuseMail *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"abuse_mail"`
+	AbuseMail *string `json:"abuse_mail"`
 
 	// Cidr The CIDR
-	Cidr *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"cidr"`
+	Cidr *int `json:"cidr"`
 
 	// Country The country
-	Country *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"country"`
+	Country *string `json:"country"`
 
 	// NetDescription The network description
-	NetDescription *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"net_description"`
+	NetDescription *string `json:"net_description"`
 
 	// NetName The network name
-	NetName *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"net_name"`
+	NetName *string `json:"net_name"`
 
 	// NetRange The network range
-	NetRange *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"net_range"`
+	NetRange *string `json:"net_range"`
 
 	// NetType The network type
-	NetType *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"net_type"`
+	NetType *string `json:"net_type"`
 
 	// OrgId The organization ID
-	OrgId *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"org_id"`
+	OrgId *string `json:"org_id"`
 
 	// OrgName The organization name
-	OrgName *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"org_name"`
+	OrgName *string `json:"org_name"`
 
 	// OwnerType The owner type
-	OwnerType *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"owner_type"`
+	OwnerType *string `json:"owner_type"`
 
 	// Rir The RIR
-	Rir *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"rir"`
+	Rir *string `json:"rir"`
 
 	// State The state
-	State *struct {
-		// Embedded fields due to inline allOf schema
-	} `json:"state"`
+	State *string `json:"state"`
 }
 
 // AppModelsApiDiscoveryApiUrls Request model for updating the API URLs
@@ -3109,10 +2777,7 @@ type GetDomainsV1DomainsGetParams struct {
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 
 	// Status Filter domains based on the domain status
-	Status *struct {
-		// Embedded struct due to allOf(#/components/schemas/DomainStatus)
-		DomainStatus `yaml:",inline"`
-	} `form:"status,omitempty" json:"status,omitempty"`
+	Status *DomainStatus `form:"status,omitempty" json:"status,omitempty"`
 
 	// Name Filter domains based on the domain name. Supports '*' as a wildcard character
 	Name *string `form:"name,omitempty" json:"name,omitempty"`
@@ -3127,9 +2792,7 @@ type GetDomainsV1DomainsGetParamsOrdering string
 // GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParams defines parameters for GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGet.
 type GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParams struct {
 	// Ordering Determine the field to order results by
-	Ordering *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"ordering,omitempty" json:"ordering,omitempty"`
+	Ordering *GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering `form:"ordering,omitempty" json:"ordering,omitempty"`
 
 	// Limit Number of items to return
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
@@ -3144,10 +2807,7 @@ type GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParams struct {
 	Description *string `form:"description,omitempty" json:"description,omitempty"`
 
 	// Action Filter to refine results by specific actions
-	Action *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleActionType)
-		RuleActionType `yaml:",inline"`
-	} `form:"action,omitempty" json:"action,omitempty"`
+	Action *RuleActionType `form:"action,omitempty" json:"action,omitempty"`
 
 	// Enabled Filter rules based on their active status
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty"`
@@ -3163,6 +2823,9 @@ type GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParams struct {
 	Phase *GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsPhase `form:"phase,omitempty" json:"phase,omitempty"`
 }
 
+// GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering defines parameters for GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGet.
+type GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsOrdering string
+
 // GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsPhase defines parameters for GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGet.
 type GetAdvancedRulesV1DomainsDomainIdAdvancedRulesGetParamsPhase string
 
@@ -3172,21 +2835,13 @@ type GetScanResultsV1DomainsDomainIdApiDiscoveryScanResultsGetParams struct {
 	Ordering *GetScanResultsV1DomainsDomainIdApiDiscoveryScanResultsGetParamsOrdering `form:"ordering,omitempty" json:"ordering,omitempty"`
 
 	// Type Filter by the path of the scan type
-	Type *struct {
-		// Embedded struct due to allOf(#/components/schemas/ApiScanType)
-		ApiScanType `yaml:",inline"`
-	} `form:"type,omitempty" json:"type,omitempty"`
+	Type *ApiScanType `form:"type,omitempty" json:"type,omitempty"`
 
 	// Status Filter by the status of the scan
-	Status *struct {
-		// Embedded struct due to allOf(#/components/schemas/TaskResultStatus)
-		TaskResultStatus `yaml:",inline"`
-	} `form:"status,omitempty" json:"status,omitempty"`
+	Status *TaskResultStatus `form:"status,omitempty" json:"status,omitempty"`
 
 	// Message Filter by the message of the scan. Supports '*' as a wildcard character
-	Message *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"message,omitempty" json:"message,omitempty"`
+	Message *string `form:"message,omitempty" json:"message,omitempty"`
 
 	// Limit Number of items to return
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
@@ -3204,47 +2859,28 @@ type GetApiPathsV1DomainsDomainIdApiPathsGetParams struct {
 	Ordering *GetApiPathsV1DomainsDomainIdApiPathsGetParamsOrdering `form:"ordering,omitempty" json:"ordering,omitempty"`
 
 	// Ids Filter by the path ID
-	Ids *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"ids,omitempty" json:"ids,omitempty"`
+	Ids *[]openapi_types.UUID `form:"ids,omitempty" json:"ids,omitempty"`
 
 	// Path Filter by the path. Supports '*' as a wildcard character
-	Path *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"path,omitempty" json:"path,omitempty"`
+	Path *string `form:"path,omitempty" json:"path,omitempty"`
 
 	// Method Filter by the API RESTful method
-	Method *struct {
-		// Embedded struct due to allOf(#/components/schemas/ApiPathMethod)
-		ApiPathMethod `yaml:",inline"`
-	} `form:"method,omitempty" json:"method,omitempty"`
+	Method *ApiPathMethod `form:"method,omitempty" json:"method,omitempty"`
 
 	// ApiVersion Filter by the API version
-	ApiVersion *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"api_version,omitempty" json:"api_version,omitempty"`
+	ApiVersion *string `form:"api_version,omitempty" json:"api_version,omitempty"`
 
 	// HttpScheme Filter by the HTTP version of the API path
-	HttpScheme *struct {
-		// Embedded struct due to allOf(#/components/schemas/ApiPathHttpScheme)
-		ApiPathHttpScheme `yaml:",inline"`
-	} `form:"http_scheme,omitempty" json:"http_scheme,omitempty"`
+	HttpScheme *ApiPathHttpScheme `form:"http_scheme,omitempty" json:"http_scheme,omitempty"`
 
 	// ApiGroup Filter by the API group associated with the API path
-	ApiGroup *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"api_group,omitempty" json:"api_group,omitempty"`
+	ApiGroup *string `form:"api_group,omitempty" json:"api_group,omitempty"`
 
 	// Status Filter by the status of the discovered API path
-	Status *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"status,omitempty" json:"status,omitempty"`
+	Status *[]ApiPathStatus `form:"status,omitempty" json:"status,omitempty"`
 
 	// Source Filter by the source of the discovered API
-	Source *struct {
-		// Embedded struct due to allOf(#/components/schemas/ApiPathSource)
-		ApiPathSource `yaml:",inline"`
-	} `form:"source,omitempty" json:"source,omitempty"`
+	Source *ApiPathSource `form:"source,omitempty" json:"source,omitempty"`
 
 	// Limit Number of items to return
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
@@ -3259,9 +2895,7 @@ type GetApiPathsV1DomainsDomainIdApiPathsGetParamsOrdering string
 // GetCustomRulesV1DomainsDomainIdCustomRulesGetParams defines parameters for GetCustomRulesV1DomainsDomainIdCustomRulesGet.
 type GetCustomRulesV1DomainsDomainIdCustomRulesGetParams struct {
 	// Ordering Determine the field to order results by
-	Ordering *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"ordering,omitempty" json:"ordering,omitempty"`
+	Ordering *GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering `form:"ordering,omitempty" json:"ordering,omitempty"`
 
 	// Limit Number of items to return
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
@@ -3276,14 +2910,14 @@ type GetCustomRulesV1DomainsDomainIdCustomRulesGetParams struct {
 	Description *string `form:"description,omitempty" json:"description,omitempty"`
 
 	// Action Filter to refine results by specific actions
-	Action *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleActionType)
-		RuleActionType `yaml:",inline"`
-	} `form:"action,omitempty" json:"action,omitempty"`
+	Action *RuleActionType `form:"action,omitempty" json:"action,omitempty"`
 
 	// Enabled Filter rules based on their active status
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty"`
 }
+
+// GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering defines parameters for GetCustomRulesV1DomainsDomainIdCustomRulesGet.
+type GetCustomRulesV1DomainsDomainIdCustomRulesGetParamsOrdering string
 
 // GetDdosAttacksV1DomainsDomainIdDdosAttacksGetParams defines parameters for GetDdosAttacksV1DomainsDomainIdDdosAttacksGet.
 type GetDdosAttacksV1DomainsDomainIdDdosAttacksGetParams struct {
@@ -3297,14 +2931,10 @@ type GetDdosAttacksV1DomainsDomainIdDdosAttacksGetParams struct {
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 
 	// StartTime Filter attacks starting from a specified date in ISO 8601 format
-	StartTime *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"start_time,omitempty" json:"start_time,omitempty"`
+	StartTime *time.Time `form:"start_time,omitempty" json:"start_time,omitempty"`
 
 	// EndTime Filter attacks up to a specified end date in ISO 8601 format
-	EndTime *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"end_time,omitempty" json:"end_time,omitempty"`
+	EndTime *time.Time `form:"end_time,omitempty" json:"end_time,omitempty"`
 }
 
 // GetDdosAttacksV1DomainsDomainIdDdosAttacksGetParamsOrdering defines parameters for GetDdosAttacksV1DomainsDomainIdDdosAttacksGet.
@@ -3334,9 +2964,7 @@ type GetDdosInfoV1DomainsDomainIdDdosInfoGetParamsGroupBy string
 // GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParams defines parameters for GetFirewallRulesV1DomainsDomainIdFirewallRulesGet.
 type GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParams struct {
 	// Ordering Determine the field to order results by
-	Ordering *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"ordering,omitempty" json:"ordering,omitempty"`
+	Ordering *GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering `form:"ordering,omitempty" json:"ordering,omitempty"`
 
 	// Limit Number of items to return
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
@@ -3351,21 +2979,18 @@ type GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParams struct {
 	Description *string `form:"description,omitempty" json:"description,omitempty"`
 
 	// Action Filter to refine results by specific actions
-	Action *struct {
-		// Embedded struct due to allOf(#/components/schemas/RuleActionType)
-		RuleActionType `yaml:",inline"`
-	} `form:"action,omitempty" json:"action,omitempty"`
+	Action *RuleActionType `form:"action,omitempty" json:"action,omitempty"`
 
 	// Enabled Filter rules based on their active status
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty"`
 }
 
+// GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering defines parameters for GetFirewallRulesV1DomainsDomainIdFirewallRulesGet.
+type GetFirewallRulesV1DomainsDomainIdFirewallRulesGetParamsOrdering string
+
 // GetInsightSilencesV1DomainsDomainIdInsightSilencesGetParams defines parameters for GetInsightSilencesV1DomainsDomainIdInsightSilencesGet.
 type GetInsightSilencesV1DomainsDomainIdInsightSilencesGetParams struct {
-	Ordering *struct {
-		// Embedded struct due to allOf(#/components/schemas/InsightSilenceSortBy)
-		InsightSilenceSortBy `yaml:",inline"`
-	} `form:"ordering,omitempty" json:"ordering,omitempty"`
+	Ordering *InsightSilenceSortBy `form:"ordering,omitempty" json:"ordering,omitempty"`
 
 	// Limit Number of items to return
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
@@ -3374,32 +2999,21 @@ type GetInsightSilencesV1DomainsDomainIdInsightSilencesGetParams struct {
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 
 	// Id The ID of the insight silence
-	Id *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"id,omitempty" json:"id,omitempty"`
+	Id *[]openapi_types.UUID `form:"id,omitempty" json:"id,omitempty"`
 
 	// InsightType The type of the insight silence
-	InsightType *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"insight_type,omitempty" json:"insight_type,omitempty"`
+	InsightType *[]string `form:"insight_type,omitempty" json:"insight_type,omitempty"`
 
 	// Comment The comment of the insight silence
-	Comment *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"comment,omitempty" json:"comment,omitempty"`
+	Comment *string `form:"comment,omitempty" json:"comment,omitempty"`
 
 	// Author The author of the insight silence
-	Author *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"author,omitempty" json:"author,omitempty"`
+	Author *string `form:"author,omitempty" json:"author,omitempty"`
 }
 
 // GetInsightsV1DomainsDomainIdInsightsGetParams defines parameters for GetInsightsV1DomainsDomainIdInsightsGet.
 type GetInsightsV1DomainsDomainIdInsightsGetParams struct {
-	Ordering *struct {
-		// Embedded struct due to allOf(#/components/schemas/InsightSortBy)
-		InsightSortBy `yaml:",inline"`
-	} `form:"ordering,omitempty" json:"ordering,omitempty"`
+	Ordering *InsightSortBy `form:"ordering,omitempty" json:"ordering,omitempty"`
 
 	// Limit Number of items to return
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
@@ -3408,24 +3022,16 @@ type GetInsightsV1DomainsDomainIdInsightsGetParams struct {
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 
 	// Id The ID of the insight
-	Id *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"id,omitempty" json:"id,omitempty"`
+	Id *[]openapi_types.UUID `form:"id,omitempty" json:"id,omitempty"`
 
 	// InsightType The type of the insight
-	InsightType *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"insight_type,omitempty" json:"insight_type,omitempty"`
+	InsightType *[]string `form:"insight_type,omitempty" json:"insight_type,omitempty"`
 
 	// Status The status of the insight
-	Status *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"status,omitempty" json:"status,omitempty"`
+	Status *[]InsightStatus `form:"status,omitempty" json:"status,omitempty"`
 
 	// Description The description of the insight. Supports '*' as a wildcard.
-	Description *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"description,omitempty" json:"description,omitempty"`
+	Description *string `form:"description,omitempty" json:"description,omitempty"`
 }
 
 // GetRequestsV1DomainsDomainIdRequestsGetParams defines parameters for GetRequestsV1DomainsDomainIdRequestsGet.
@@ -3479,33 +3085,28 @@ type GetEventStatisticsV1DomainsDomainIdStatsGetParams struct {
 	End *time.Time `form:"end,omitempty" json:"end,omitempty"`
 
 	// Ip A list of IPs to filter event statistics.
-	Ip *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"ip,omitempty" json:"ip,omitempty"`
+	Ip *[]string `form:"ip,omitempty" json:"ip,omitempty"`
 
 	// ReferenceId A list of reference IDs to filter event statistics.
-	ReferenceId *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"reference_id,omitempty" json:"reference_id,omitempty"`
+	ReferenceId *[]string `form:"reference_id,omitempty" json:"reference_id,omitempty"`
 
 	// Action A list of action names to filter on.
-	Action *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"action,omitempty" json:"action,omitempty"`
+	Action *[]GetEventStatisticsV1DomainsDomainIdStatsGetParamsAction `form:"action,omitempty" json:"action,omitempty"`
 
 	// Result A list of results to filter event statistics.
-	Result *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"result,omitempty" json:"result,omitempty"`
+	Result *[]GetEventStatisticsV1DomainsDomainIdStatsGetParamsResult `form:"result,omitempty" json:"result,omitempty"`
 }
+
+// GetEventStatisticsV1DomainsDomainIdStatsGetParamsAction defines parameters for GetEventStatisticsV1DomainsDomainIdStatsGet.
+type GetEventStatisticsV1DomainsDomainIdStatsGetParamsAction string
+
+// GetEventStatisticsV1DomainsDomainIdStatsGetParamsResult defines parameters for GetEventStatisticsV1DomainsDomainIdStatsGet.
+type GetEventStatisticsV1DomainsDomainIdStatsGetParamsResult string
 
 // GetTrafficV1DomainsDomainIdTrafficGetParams defines parameters for GetTrafficV1DomainsDomainIdTrafficGet.
 type GetTrafficV1DomainsDomainIdTrafficGetParams struct {
 	// Resolution Specifies the granularity of the result data.
-	Resolution struct {
-		// Embedded struct due to allOf(#/components/schemas/Resolution)
-		Resolution `yaml:",inline"`
-	} `form:"resolution" json:"resolution"`
+	Resolution Resolution `form:"resolution" json:"resolution"`
 
 	// Start Filter traffic starting from a specified date in ISO 8601 format
 	Start time.Time `form:"start" json:"start"`
@@ -3658,9 +3259,7 @@ type GetTopUserAgentsV1IpInfoTopUserAgentsGetParamsIp1 = string
 // GetOrganizationsV1OrganizationsGetParams defines parameters for GetOrganizationsV1OrganizationsGet.
 type GetOrganizationsV1OrganizationsGetParams struct {
 	// Ordering Determine the field to order results by
-	Ordering *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"ordering,omitempty" json:"ordering,omitempty"`
+	Ordering *GetOrganizationsV1OrganizationsGetParamsOrdering `form:"ordering,omitempty" json:"ordering,omitempty"`
 
 	// Limit Number of items to return
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
@@ -3671,6 +3270,9 @@ type GetOrganizationsV1OrganizationsGetParams struct {
 	// Name Filter organizations by their name. Supports '*' as a wildcard character.
 	Name *string `form:"name,omitempty" json:"name,omitempty"`
 }
+
+// GetOrganizationsV1OrganizationsGetParamsOrdering defines parameters for GetOrganizationsV1OrganizationsGet.
+type GetOrganizationsV1OrganizationsGetParamsOrdering string
 
 // PreviewCustomPageV1PreviewCustomPagePostParams defines parameters for PreviewCustomPageV1PreviewCustomPagePost.
 type PreviewCustomPageV1PreviewCustomPagePostParams struct {
@@ -3688,19 +3290,13 @@ type GetInsightTypesV1SecurityInsightsTypesGetParams struct {
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 
 	// Name Filter by the name of the insight type
-	Name *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"name,omitempty" json:"name,omitempty"`
+	Name *string `form:"name,omitempty" json:"name,omitempty"`
 
 	// Slug Filter by the slug of the insight type
-	Slug *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"slug,omitempty" json:"slug,omitempty"`
+	Slug *string `form:"slug,omitempty" json:"slug,omitempty"`
 
 	// InsightFrequency Filter by the frequency of the insight type
-	InsightFrequency *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"insight_frequency,omitempty" json:"insight_frequency,omitempty"`
+	InsightFrequency *int `form:"insight_frequency,omitempty" json:"insight_frequency,omitempty"`
 }
 
 // GetInsightTypesV1SecurityInsightsTypesGetParamsOrdering defines parameters for GetInsightTypesV1SecurityInsightsTypesGet.
@@ -3730,9 +3326,7 @@ type GetStatisticsSeriesV1StatisticsSeriesGetParamsMetrics string
 // GetTagsV1TagsGetParams defines parameters for GetTagsV1TagsGet.
 type GetTagsV1TagsGetParams struct {
 	// Ordering Determine the field to order results by
-	Ordering *struct {
-		// Embedded fields due to inline allOf schema
-	} `form:"ordering,omitempty" json:"ordering,omitempty"`
+	Ordering *GetTagsV1TagsGetParamsOrdering `form:"ordering,omitempty" json:"ordering,omitempty"`
 
 	// Limit Number of items to return
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
@@ -3746,6 +3340,9 @@ type GetTagsV1TagsGetParams struct {
 	// Reserved Filter to include only reserved tags.
 	Reserved *bool `form:"reserved,omitempty" json:"reserved,omitempty"`
 }
+
+// GetTagsV1TagsGetParamsOrdering defines parameters for GetTagsV1TagsGet.
+type GetTagsV1TagsGetParamsOrdering string
 
 // CreateCustomPageSetV1CustomPageSetsPostJSONRequestBody defines body for CreateCustomPageSetV1CustomPageSetsPost for application/json ContentType.
 type CreateCustomPageSetV1CustomPageSetsPostJSONRequestBody = CustomPageSetCreate
@@ -4616,6 +4213,68 @@ func (t *IpRangeCondition_UpperBound) UnmarshalJSON(b []byte) error {
 	return err
 }
 
+// AsRequestRateConditionIps0 returns the union data inside the RequestRateCondition_Ips_Item as a RequestRateConditionIps0
+func (t RequestRateCondition_Ips_Item) AsRequestRateConditionIps0() (RequestRateConditionIps0, error) {
+	var body RequestRateConditionIps0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRequestRateConditionIps0 overwrites any union data inside the RequestRateCondition_Ips_Item as the provided RequestRateConditionIps0
+func (t *RequestRateCondition_Ips_Item) FromRequestRateConditionIps0(v RequestRateConditionIps0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRequestRateConditionIps0 performs a merge with any union data inside the RequestRateCondition_Ips_Item, using the provided RequestRateConditionIps0
+func (t *RequestRateCondition_Ips_Item) MergeRequestRateConditionIps0(v RequestRateConditionIps0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsRequestRateConditionIps1 returns the union data inside the RequestRateCondition_Ips_Item as a RequestRateConditionIps1
+func (t RequestRateCondition_Ips_Item) AsRequestRateConditionIps1() (RequestRateConditionIps1, error) {
+	var body RequestRateConditionIps1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRequestRateConditionIps1 overwrites any union data inside the RequestRateCondition_Ips_Item as the provided RequestRateConditionIps1
+func (t *RequestRateCondition_Ips_Item) FromRequestRateConditionIps1(v RequestRateConditionIps1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRequestRateConditionIps1 performs a merge with any union data inside the RequestRateCondition_Ips_Item, using the provided RequestRateConditionIps1
+func (t *RequestRateCondition_Ips_Item) MergeRequestRateConditionIps1(v RequestRateConditionIps1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t RequestRateCondition_Ips_Item) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *RequestRateCondition_Ips_Item) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
 
@@ -4748,10 +4407,7 @@ type ClientInterface interface {
 	UpdateAdvancedRuleV1DomainsDomainIdAdvancedRulesRuleIdPatch(ctx context.Context, domainId int, ruleId int, body UpdateAdvancedRuleV1DomainsDomainIdAdvancedRulesRuleIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatch request
-	ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatch(ctx context.Context, domainId int, ruleId int, action struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-		CustomerRuleState `yaml:",inline"`
-	}, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatch(ctx context.Context, domainId int, ruleId int, action CustomerRuleState, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetApiUrlsV1DomainsDomainIdApiDiscoveryApiUrlsGet request
 	GetApiUrlsV1DomainsDomainIdApiDiscoveryApiUrlsGet(ctx context.Context, domainId int, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4830,10 +4486,7 @@ type ClientInterface interface {
 	UpdateCustomRuleV1DomainsDomainIdCustomRulesRuleIdPatch(ctx context.Context, domainId int, ruleId int, body UpdateCustomRuleV1DomainsDomainIdCustomRulesRuleIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatch request
-	ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatch(ctx context.Context, domainId int, ruleId int, action struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-		CustomerRuleState `yaml:",inline"`
-	}, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatch(ctx context.Context, domainId int, ruleId int, action CustomerRuleState, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetDdosAttacksV1DomainsDomainIdDdosAttacksGet request
 	GetDdosAttacksV1DomainsDomainIdDdosAttacksGet(ctx context.Context, domainId int, params *GetDdosAttacksV1DomainsDomainIdDdosAttacksGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4866,10 +4519,7 @@ type ClientInterface interface {
 	UpdateFirewallRuleV1DomainsDomainIdFirewallRulesRuleIdPatch(ctx context.Context, domainId int, ruleId int, body UpdateFirewallRuleV1DomainsDomainIdFirewallRulesRuleIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatch request
-	ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatch(ctx context.Context, domainId int, ruleId int, action struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-		CustomerRuleState `yaml:",inline"`
-	}, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatch(ctx context.Context, domainId int, ruleId int, action CustomerRuleState, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetInsightSilencesV1DomainsDomainIdInsightSilencesGet request
 	GetInsightSilencesV1DomainsDomainIdInsightSilencesGet(ctx context.Context, domainId int, params *GetInsightSilencesV1DomainsDomainIdInsightSilencesGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5224,10 +4874,7 @@ func (c *ClientSDK) UpdateAdvancedRuleV1DomainsDomainIdAdvancedRulesRuleIdPatch(
 	return c.Client.Do(req)
 }
 
-func (c *ClientSDK) ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatch(ctx context.Context, domainId int, ruleId int, action struct {
-	// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-	CustomerRuleState `yaml:",inline"`
-}, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *ClientSDK) ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatch(ctx context.Context, domainId int, ruleId int, action CustomerRuleState, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchRequest(c.Server, domainId, ruleId, action)
 	if err != nil {
 		return nil, err
@@ -5575,10 +5222,7 @@ func (c *ClientSDK) UpdateCustomRuleV1DomainsDomainIdCustomRulesRuleIdPatch(ctx 
 	return c.Client.Do(req)
 }
 
-func (c *ClientSDK) ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatch(ctx context.Context, domainId int, ruleId int, action struct {
-	// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-	CustomerRuleState `yaml:",inline"`
-}, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *ClientSDK) ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatch(ctx context.Context, domainId int, ruleId int, action CustomerRuleState, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchRequest(c.Server, domainId, ruleId, action)
 	if err != nil {
 		return nil, err
@@ -5722,10 +5366,7 @@ func (c *ClientSDK) UpdateFirewallRuleV1DomainsDomainIdFirewallRulesRuleIdPatch(
 	return c.Client.Do(req)
 }
 
-func (c *ClientSDK) ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatch(ctx context.Context, domainId int, ruleId int, action struct {
-	// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-	CustomerRuleState `yaml:",inline"`
-}, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *ClientSDK) ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatch(ctx context.Context, domainId int, ruleId int, action CustomerRuleState, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchRequest(c.Server, domainId, ruleId, action)
 	if err != nil {
 		return nil, err
@@ -7075,10 +6716,7 @@ func NewUpdateAdvancedRuleV1DomainsDomainIdAdvancedRulesRuleIdPatchRequestWithBo
 }
 
 // NewToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchRequest generates requests for ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatch
-func NewToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchRequest(server string, domainId int, ruleId int, action struct {
-	// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-	CustomerRuleState `yaml:",inline"`
-}) (*http.Request, error) {
+func NewToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchRequest(server string, domainId int, ruleId int, action CustomerRuleState) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8361,10 +7999,7 @@ func NewUpdateCustomRuleV1DomainsDomainIdCustomRulesRuleIdPatchRequestWithBody(s
 }
 
 // NewToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchRequest generates requests for ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatch
-func NewToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchRequest(server string, domainId int, ruleId int, action struct {
-	// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-	CustomerRuleState `yaml:",inline"`
-}) (*http.Request, error) {
+func NewToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchRequest(server string, domainId int, ruleId int, action CustomerRuleState) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -9026,10 +8661,7 @@ func NewUpdateFirewallRuleV1DomainsDomainIdFirewallRulesRuleIdPatchRequestWithBo
 }
 
 // NewToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchRequest generates requests for ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatch
-func NewToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchRequest(server string, domainId int, ruleId int, action struct {
-	// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-	CustomerRuleState `yaml:",inline"`
-}) (*http.Request, error) {
+func NewToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchRequest(server string, domainId int, ruleId int, action CustomerRuleState) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -11344,10 +10976,7 @@ type ClientWithResponsesInterface interface {
 	UpdateAdvancedRuleV1DomainsDomainIdAdvancedRulesRuleIdPatchWithResponse(ctx context.Context, domainId int, ruleId int, body UpdateAdvancedRuleV1DomainsDomainIdAdvancedRulesRuleIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAdvancedRuleV1DomainsDomainIdAdvancedRulesRuleIdPatchResponse, error)
 
 	// ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchWithResponse request
-	ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchWithResponse(ctx context.Context, domainId int, ruleId int, action struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-		CustomerRuleState `yaml:",inline"`
-	}, reqEditors ...RequestEditorFn) (*ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchResponse, error)
+	ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchWithResponse(ctx context.Context, domainId int, ruleId int, action CustomerRuleState, reqEditors ...RequestEditorFn) (*ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchResponse, error)
 
 	// GetApiUrlsV1DomainsDomainIdApiDiscoveryApiUrlsGetWithResponse request
 	GetApiUrlsV1DomainsDomainIdApiDiscoveryApiUrlsGetWithResponse(ctx context.Context, domainId int, reqEditors ...RequestEditorFn) (*GetApiUrlsV1DomainsDomainIdApiDiscoveryApiUrlsGetResponse, error)
@@ -11426,10 +11055,7 @@ type ClientWithResponsesInterface interface {
 	UpdateCustomRuleV1DomainsDomainIdCustomRulesRuleIdPatchWithResponse(ctx context.Context, domainId int, ruleId int, body UpdateCustomRuleV1DomainsDomainIdCustomRulesRuleIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateCustomRuleV1DomainsDomainIdCustomRulesRuleIdPatchResponse, error)
 
 	// ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchWithResponse request
-	ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchWithResponse(ctx context.Context, domainId int, ruleId int, action struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-		CustomerRuleState `yaml:",inline"`
-	}, reqEditors ...RequestEditorFn) (*ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchResponse, error)
+	ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchWithResponse(ctx context.Context, domainId int, ruleId int, action CustomerRuleState, reqEditors ...RequestEditorFn) (*ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchResponse, error)
 
 	// GetDdosAttacksV1DomainsDomainIdDdosAttacksGetWithResponse request
 	GetDdosAttacksV1DomainsDomainIdDdosAttacksGetWithResponse(ctx context.Context, domainId int, params *GetDdosAttacksV1DomainsDomainIdDdosAttacksGetParams, reqEditors ...RequestEditorFn) (*GetDdosAttacksV1DomainsDomainIdDdosAttacksGetResponse, error)
@@ -11462,10 +11088,7 @@ type ClientWithResponsesInterface interface {
 	UpdateFirewallRuleV1DomainsDomainIdFirewallRulesRuleIdPatchWithResponse(ctx context.Context, domainId int, ruleId int, body UpdateFirewallRuleV1DomainsDomainIdFirewallRulesRuleIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateFirewallRuleV1DomainsDomainIdFirewallRulesRuleIdPatchResponse, error)
 
 	// ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchWithResponse request
-	ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchWithResponse(ctx context.Context, domainId int, ruleId int, action struct {
-		// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-		CustomerRuleState `yaml:",inline"`
-	}, reqEditors ...RequestEditorFn) (*ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchResponse, error)
+	ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchWithResponse(ctx context.Context, domainId int, ruleId int, action CustomerRuleState, reqEditors ...RequestEditorFn) (*ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchResponse, error)
 
 	// GetInsightSilencesV1DomainsDomainIdInsightSilencesGetWithResponse request
 	GetInsightSilencesV1DomainsDomainIdInsightSilencesGetWithResponse(ctx context.Context, domainId int, params *GetInsightSilencesV1DomainsDomainIdInsightSilencesGetParams, reqEditors ...RequestEditorFn) (*GetInsightSilencesV1DomainsDomainIdInsightSilencesGetResponse, error)
@@ -13709,10 +13332,7 @@ func (c *ClientWithResponses) UpdateAdvancedRuleV1DomainsDomainIdAdvancedRulesRu
 }
 
 // ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchWithResponse request returning *ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchResponse
-func (c *ClientWithResponses) ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchWithResponse(ctx context.Context, domainId int, ruleId int, action struct {
-	// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-	CustomerRuleState `yaml:",inline"`
-}, reqEditors ...RequestEditorFn) (*ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchResponse, error) {
+func (c *ClientWithResponses) ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchWithResponse(ctx context.Context, domainId int, ruleId int, action CustomerRuleState, reqEditors ...RequestEditorFn) (*ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatchResponse, error) {
 	rsp, err := c.ToggleRuleV1DomainsDomainIdAdvancedRulesRuleIdActionPatch(ctx, domainId, ruleId, action, reqEditors...)
 	if err != nil {
 		return nil, err
@@ -13965,10 +13585,7 @@ func (c *ClientWithResponses) UpdateCustomRuleV1DomainsDomainIdCustomRulesRuleId
 }
 
 // ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchWithResponse request returning *ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchResponse
-func (c *ClientWithResponses) ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchWithResponse(ctx context.Context, domainId int, ruleId int, action struct {
-	// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-	CustomerRuleState `yaml:",inline"`
-}, reqEditors ...RequestEditorFn) (*ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchResponse, error) {
+func (c *ClientWithResponses) ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchWithResponse(ctx context.Context, domainId int, ruleId int, action CustomerRuleState, reqEditors ...RequestEditorFn) (*ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatchResponse, error) {
 	rsp, err := c.ToggleRuleV1DomainsDomainIdCustomRulesRuleIdActionPatch(ctx, domainId, ruleId, action, reqEditors...)
 	if err != nil {
 		return nil, err
@@ -14073,10 +13690,7 @@ func (c *ClientWithResponses) UpdateFirewallRuleV1DomainsDomainIdFirewallRulesRu
 }
 
 // ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchWithResponse request returning *ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchResponse
-func (c *ClientWithResponses) ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchWithResponse(ctx context.Context, domainId int, ruleId int, action struct {
-	// Embedded struct due to allOf(#/components/schemas/CustomerRuleState)
-	CustomerRuleState `yaml:",inline"`
-}, reqEditors ...RequestEditorFn) (*ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchResponse, error) {
+func (c *ClientWithResponses) ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchWithResponse(ctx context.Context, domainId int, ruleId int, action CustomerRuleState, reqEditors ...RequestEditorFn) (*ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatchResponse, error) {
 	rsp, err := c.ToggleRuleV1DomainsDomainIdFirewallRulesRuleIdActionPatch(ctx, domainId, ruleId, action, reqEditors...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Removed `old-merge-schemas` from `oapi-gen.yml` due to some undesired behavior in the generated SDK. 